### PR TITLE
Fix method lookup for service wrapper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echo-health/grpc-interceptors",
-  "version": "0.0.1",
+  "version": "0.0.6",
   "scripts": {
     "test": "jest",
     "lint": "eslint . --fix",
@@ -18,5 +18,20 @@
     "eslint-plugin-jest": "^21.15.1",
     "jest": "^22.4.3",
     "protobufjs": "^6.8.6"
-  }
+  },
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/echo-health/node-grpc-interceptors.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/echo-health/node-grpc-interceptors/issues"
+  },
+  "homepage": "https://github.com/echo-health/node-grpc-interceptors#readme",
+  "description": ""
 }

--- a/test/message.proto
+++ b/test/message.proto
@@ -4,6 +4,7 @@ package Test;
 service Messenger {
   rpc Greet (MessageRequest) returns (MessageReply) {}
   rpc Wave (MessageRequest) returns (MessageReply) {} 
+  rpc WaveAgain (MessageRequest) returns (MessageReply) {} 
 }
 
 message MessageRequest {

--- a/test/test-service.js
+++ b/test/test-service.js
@@ -10,9 +10,13 @@ function Wave(call, callback) {
     return callback(null, { message: 'Wave' });
 }
 
+function WaveAgain(call, callback) {
+    return callback(null, { message: 'Wave' });
+}
+
 module.exports = port => {
     const server = interceptors.serverProxy(new grpc.Server());
-    server.addService(proto.Test.Messenger.service, { Greet, Wave });
+    server.addService(proto.Test.Messenger.service, { Greet, Wave, WaveAgain });
     server.bind(`localhost:${port}`, grpc.ServerCredentials.createInsecure());
     const client = interceptors.clientProxy(new proto.Test.Messenger(`localhost:${port}`, grpc.credentials.createInsecure()));
     return { server, client };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,18 +1,24 @@
 const proto = require('./proto');
 const utils = require('../utils');
 
-const Greet = (call, next) => {
-    next();
+const Greet = (call, callback) => {
+    callback();
 };
 
-const Wave = (call, next) => {
-    next();
+const WaveAgain = (call, callback) => {
+    callback();
+};
+
+const waveAgain = WaveAgain;
+
+const Wave = (call, callback) => {
+    callback();
 };
 
 describe('lookup service metadata', () => {
 
     test('should lookup service metadata from implementation key', done => {
-        const lookup = utils.lookupServiceMetadata(proto.Test.Messenger.service, { Greet, Wave });
+        const lookup = utils.lookupServiceMetadata(proto.Test.Messenger.service, { Greet, Wave, WaveAgain });
         const result = lookup('Wave');
         expect(result).toBeDefined();
         expect(result.name).toBe('Test.Messenger');
@@ -22,11 +28,34 @@ describe('lookup service metadata', () => {
         done();
     });
 
-    test('should return undeifned if implementation method isn\'t found', done => {
-        const lookup = utils.lookupServiceMetadata(proto.Test.Messenger.service, { Greet, Wave });
+    test('should return undefined if implementation method isn\'t found', done => {
+        const lookup = utils.lookupServiceMetadata(proto.Test.Messenger.service, { Greet, Wave, WaveAgain });
         const result = lookup('NotDefined');
         expect(result).toBeUndefined();
         done();
     });
+
+    test('should return method definition if method name is more than one word and has upper camelcase implemntation', done => {
+        const lookup = utils.lookupServiceMetadata(proto.Test.Messenger.service, { Greet, Wave, WaveAgain });
+        const result = lookup('WaveAgain');
+        expect(result).toBeDefined();
+        expect(result.name).toBe('Test.Messenger');
+        expect(result.method).toBe('WaveAgain');
+        expect(result.type).toBe('unary');
+        expect(result.path).toBe('/Test.Messenger/WaveAgain');
+        done();
+    });
+
+    test('should return method definition if method name is more than one word and has lower camelcase implemntation', done => {
+        const lookup = utils.lookupServiceMetadata(proto.Test.Messenger.service, { Greet, Wave, waveAgain });
+        const result = lookup('WaveAgain');
+        expect(result).toBeDefined();
+        expect(result.name).toBe('Test.Messenger');
+        expect(result.method).toBe('WaveAgain');
+        expect(result.type).toBe('unary');
+        expect(result.path).toBe('/Test.Messenger/WaveAgain');
+        done();
+    });
+
 
 });


### PR DESCRIPTION
need to lookup the method by lower camelcase. Grpc always uses
lower camelcase for it's method names. We need to normalise the
implementation method names to lookup up the service method definition.