### PR TITLE
Make sure the returned status object to ctx is consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echo-health/grpc-interceptors",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "scripts": {
     "test": "jest",
     "lint": "eslint . --fix",

--- a/server-proxy.js
+++ b/server-proxy.js
@@ -27,7 +27,10 @@ const handler = {
                             };
                             const err = args[0];
                             if (err) {
-                                ctx.status = err;
+                                ctx.status = {
+                                    code: grpc.status.UNKNOWN,
+                                    details: err,
+                                };
                             }
                             callback(...args);
                         };


### PR DESCRIPTION
If a err is found, default to UNKNOWN status and return the details of
the error.